### PR TITLE
Fix link color for IE and obsolete Microsoft Edge

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -57,9 +57,8 @@
             </ul>
           </p>
           <div class="buttons">
-            <a class="call-to-action button button--primary" href="./kurs.html" target="_blank"
-              title="Kurs starten">Kurs starten</a>
-            <a class="call-to-action button button--2ndary cta05" href="#prizing" title="Jetzt buchen">Jetzt buchen</a>
+            <a class="button button--primary" href="./kurs.html" target="_blank" title="Kurs starten">Kurs starten</a>
+            <a class="button button--2ndary cta05" href="#prizing" title="Jetzt buchen">Jetzt buchen</a>
           </div>
           <img class='early-bird__icon' src="imgs/early-birds.svg">
         </div>
@@ -174,9 +173,8 @@
           </div>
         </div>
         <div class="buttons">
-          <a class="call-to-action button button--primary" href="./kurs.html" target="_blank" title="Kurs starten">Kurs
-            starten</a>
-          <a class="call-to-action button button--2ndary cta05" href="#prizing" title="Jeztzt buchen">Jetzt buchen</a>
+          <a class="button button--primary" href="./kurs.html" target="_blank" title="Kurs starten">Kurs starten</a>
+          <a class="button button--2ndary cta05" href="#prizing" title="Jeztzt buchen">Jetzt buchen</a>
         </div>
       </section>
       <section class="section section--prizing" id="prizing">
@@ -200,8 +198,7 @@
               <div class="booking-offer__entry booking-offer__detail">inkl. Online-Meetings mit Eva und Xaver</div>
               <div class="booking-offer__entry booking-offer__detail">Noch 4 von 10 verfügbar.</div>
               <div class="buttons">
-                <a class="call-to-action button button--primary" href="./booking.html" title="Jetzt buchen">Jetzt
-                  buchen</a>
+                <a class="button button--primary" href="./booking.html" title="Jetzt buchen">Jetzt buchen</a>
               </div>
             </div>
             <div class="booking-offer">
@@ -304,9 +301,8 @@
           </p>
         </div>
         <div class="buttons">
-          <a class="call-to-action button button--primary" href="./kurs.html" target="_blank" title="Kurs starten">Kurs
-            starten</a>
-          <a class="call-to-action button button--2ndary cta05" href="#prizing" title="Jetzt buchen">Jetzt buchen</a>
+          <a class="button button--primary" href="./kurs.html" target="_blank" title="Kurs starten">Kurs starten</a>
+          <a class="button button--2ndary cta05" href="#prizing" title="Jetzt buchen">Jetzt buchen</a>
         </div>
       </section>
     </main>

--- a/dist/kurs.html
+++ b/dist/kurs.html
@@ -164,9 +164,8 @@
             Kursblocks 1: Innere Stärke</a>
         </div>
         <div class="buttons">
-          <a class="call-to-action button button--primary cta06" title="Kursblock 2">Kursblock 2</a>
-          <a class="call-to-action button button--2ndary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt
-            buchen</a>
+          <a class="button button--primary cta06" title="Kursblock 2">Kursblock 2</a>
+          <a class="button button--2ndary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt buchen</a>
         </div>
       </section>
       <section class="section hidden-by-default section--kurs02">
@@ -175,8 +174,7 @@
           <p>Bitte melde dich an, um alle Inhalte dieses Kurses zu sehen.</p>
         </div>
         <div class="buttons">
-          <a class="call-to-action button button--primary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt
-            buchen</a>
+          <a class="button button--primary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt buchen</a>
         </div>
       </section>
       <section class="section hidden-by-default section--kurs03">
@@ -184,8 +182,7 @@
         <div class="section__subsection">
           <p>Bitte melde dich an, um alle Inhalte dieses Kurses zu sehen.</p>
           <div class="buttons">
-            <a class="call-to-action button button--primary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt
-              buchen</a>
+            <a class="button button--primary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt buchen</a>
           </div>
         </div>
       </section>
@@ -194,8 +191,7 @@
         <div class="section__subsection">
           <p>Bitte melde dich an, um alle Inhalte dieses Kurses zu sehen.</p>
           <div class="buttons">
-            <a class="call-to-action button button--primary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt
-              buchen</a>
+            <a class="button button--primary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt buchen</a>
           </div>
         </div>
       </section>
@@ -204,8 +200,7 @@
         <div class="section__subsection">
           <p>Bitte melde dich an, um alle Inhalte dieses Kurses zu sehen.</p>
           <div class="buttons">
-            <a class="call-to-action button button--primary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt
-              buchen</a>
+            <a class="button button--primary cta05" href="index.html#prizing" title="Jetzt buchen">Jetzt buchen</a>
           </div>
         </div>
       </section>

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -206,7 +206,7 @@ main[data-active-block="05"] .section--kurs05 {
   color: #ffffff;
 }
 
-.footer *:any-link {
+.footer a {
   color: #ffffff;
 }
 
@@ -378,7 +378,7 @@ form {
 }
 
 /* this rule is needed to override user agents stylesheets */
-.nav *:any-link {
+.nav a {
   color: #966b40;
   text-decoration: none;
 }


### PR DESCRIPTION
Link color is incorrect in IE11 and Microsoft Edge (legacy)

Reason: CSS selector `:any-link` is not supported.